### PR TITLE
Add batch to build with msvc2019

### DIFF
--- a/cmake_msvc2019.cmd
+++ b/cmake_msvc2019.cmd
@@ -1,0 +1,4 @@
+mkdir build\msvc2019-x86
+pushd build\msvc2019-x86
+cmake -G "Visual Studio 16 2019" -A Win32 %* ../..
+popd


### PR DESCRIPTION
Sorry about that, here you go.

Compiles fine with msvc2019, though architecture needed to be specified otherwise it would default to a 64-bit project.